### PR TITLE
Some renaming and parser improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.ignore
+*.diary
+firmware/nbproject/Makefile-*
+firmware/nbproject/Package-*.bash
+firmware/nbproject/private/
+firmware/build/
+firmware/dist/
+

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -275,7 +275,7 @@ int main(void)
             memcpy(cmd_buf + cmd_ptr, out_buf, out_buf_len);
             for(int i = 0; i < out_buf_len; i++)
             {
-                if(cmd_buf[cmd_ptr + i] == '\n')
+                if(cmd_buf[cmd_ptr + i] == '\n' || cmd_buf[cmd_ptr + i] == '\r')
                 {
                     newline_found = 1;
                     cmd_ptr = 0;

--- a/firmware/parse.c
+++ b/firmware/parse.c
@@ -99,7 +99,7 @@ void parse_ascii(unsigned char * buf, parse_result_t * res)
                         buf[buf_ptr] > 'F') &&
                        hex_len <= sizeof(res->arg))
                     {
-                        if(buf[buf_ptr] == ' ' || buf[buf_ptr] == '\n')
+                        if(buf[buf_ptr] == ' ' || buf[buf_ptr] == '\n' || buf[buf_ptr] == '\r')
                         {
                             ascii_to_hex(res->arg, hex_start, sizeof(res->arg), hex_len);
                             state = IN_WHITE_2;
@@ -118,7 +118,7 @@ void parse_ascii(unsigned char * buf, parse_result_t * res)
                 {
                     // Continue
                 }
-                else if(buf[buf_ptr] == '\n')
+                else if(buf[buf_ptr] == '\n' || buf[buf_ptr] == '\r')
                 {
                     state = ACCEPT;
                 }

--- a/pytl866/examples/eprom_read.py
+++ b/pytl866/examples/eprom_read.py
@@ -65,27 +65,27 @@ def print_zif(v):
 
 
 with pytl866.Tl866Context(sys.argv[1]) as tl:
-    tl.eo()
+    tl.cmd_echo_off()
 
     # Default direction (all output).
-    tl.zd(0)
+    tl.cmd_zif_dir(0)
 
     # Set voltages
-    tl.pw(0)
-    tl.gw(0x0000002000)
-    tl.dw(1 << 39)
-    tl.ds(3)
+    tl.cmd_vpp_write(0)
+    tl.cmd_gnd_write(0x0000002000)
+    tl.cmd_vdd_write(1 << 39)
+    tl.cmd_vdd_set(3)
 
     # Set data lines as input.
-    tl.zd(eprom_to_int(d_lines))
+    tl.cmd_zif_dir(eprom_to_int(d_lines))
     res = bytearray()
     print("Initialization done. Starting read loop...")
 
     start = timer()
     for i in range(8192):
-        tl.zw(addr_bits(i) | eprom_to_int([pgm, ce, oe])) # Set up addr
-        tl.zw(addr_bits(i) | eprom_to_int([pgm, oe])) # CE low
-        tl.zw((addr_bits(i) & ~eprom_to_int([oe, ce])) | eprom_to_int([pgm])) # OE low
+        tl.cmd_zif_write(addr_bits(i) | eprom_to_int([pgm, ce, oe])) # Set up addr
+        tl.cmd_zif_write(addr_bits(i) | eprom_to_int([pgm, oe])) # CE low
+        tl.cmd_zif_write((addr_bits(i) & ~eprom_to_int([oe, ce])) | eprom_to_int([pgm])) # OE low
 
         res += get_data(tl.zr()).to_bytes(1, byteorder="little")
     end = timer()

--- a/pytl866/examples/pin_test.py
+++ b/pytl866/examples/pin_test.py
@@ -9,11 +9,11 @@ if len(sys.argv) < 2:
 
 
 with pytl866.Tl866Context(sys.argv[1]) as tl:
-    tl.eo()
-    tl.zd(0)
+    tl.cmd_echo_off()
+    tl.cmd_zif_dir(0)
     masks = [i << j for j in range(0, 40, 8) for i in range(256)]
 
     for m in masks:
-        tl.zw(m)
+        tl.cmd_zif_write(m)
         print("Write: ", format(m, "010X"))
-        print("Read: ", format(tl.zr(), "010X"))
+        print("Read: ", format(tl.cmd_zif_read(), "010X"))

--- a/pytl866/pytl866/driver.py
+++ b/pytl866/pytl866/driver.py
@@ -1,5 +1,6 @@
 import re
 import serial
+from time import sleep
 
 (VPP_98, VPP_126, VPP_140, VPP_166, VPP_144, VPP_171, VPP_185, VPP_212) = range(8)
 # My measurements: 9.83, 12.57, 14.00, 16.68, 14.46, 17.17, 18.56, 21.2
@@ -33,64 +34,64 @@ class Tl866Driver():
         return self.get_retval()
 
     # Thin command wrappers
-    def dd(self):
+    def cmd_vdd_disable(self):
         return self.mk_and_send_cmd("dd", 0)
 
-    def de(self):
+    def cmd_vdd_enable(self):
         return self.mk_and_send_cmd("de", 0)
 
-    def ds(self, val):
+    def cmd_vdd_set(self, val):
         return self.mk_and_send_cmd("ds", val)
 
-    def dw(self, val):
+    def cmd_vdd_write(self, val):
         return self.mk_and_send_cmd("dw", val)
 
-    def ee(self):
+    def cmd_echo_on(self):
         return self.mk_and_send_cmd("ee", 0)
 
-    def eo(self):
+    def cmd_echo_off(self):
         return self.mk_and_send_cmd("eo", 0)
 
-    def gw(self, val):
+    def cmd_gnd_write(self, val):
         return self.mk_and_send_cmd("gw", val)
 
-    def ll(self):
+    def cmd_led_on(self):
         return self.mk_and_send_cmd("ll", 0)
 
-    def lo(self):
+    def cmd_led_off(self):
         return self.mk_and_send_cmd("lo", 0)
 
-    def lq(self):
+    def cmd_led_query(self):
         return self.mk_and_send_cmd("lq", 0)
 
-    def mm(self):
+    def cmd_mystery_on(self):
         return self.mk_and_send_cmd("mm", 0)
 
-    def mo(self):
+    def cmd_mystery_off(self):
         return self.mk_and_send_cmd("mo", 0)
 
-    def pd(self):
+    def cmd_vpp_disable(self):
         return self.mk_and_send_cmd("pd", 0)
 
-    def pe(self):
+    def cmd_vpp_enable(self):
         return self.mk_and_send_cmd("pe", 0)
 
-    def ps(self, val):
+    def cmd_vpp_set(self, val):
         return self.mk_and_send_cmd("ps", val)
 
-    def pw(self, val):
+    def cmd_vpp_write(self, val):
         return self.mk_and_send_cmd("pw", val)
 
-    def zd(self, val):
+    def cmd_zif_dir(self, val):
         return self.mk_and_send_cmd("zd", val)
 
-    def ze(self):
+    def cmd_zif_dir_read(self):
         return self.mk_and_send_cmd("ze", 0)
 
-    def zr(self):
+    def cmd_zif_read(self):
         return self.mk_and_send_cmd("zr", 0)
 
-    def zw(self, val):
+    def cmd_zif_write(self, val):
         return self.mk_and_send_cmd("zw", val)
 
 


### PR DESCRIPTION
Adding CR support in addition to LF for line breaks in the firmware.
Preliminary testing w/ screen looks ok, but needs further testing with
CR line breaks. Eventually good to add support for CT+LF line breaks and
potentially do a parser rewrite (as discussed on IRC).

Renaming command function in the python client API for readability.
Modified examples accordingly and tested pin_test.py. Would be good to
test eprom_read.py.

Please modify the .gitignore as desired in merging. Maybe adding the XML files to it might be desirable.