### PR TITLE
Adding a mostly functional AT89C51 programming support

### DIFF
--- a/firmware/comlib.c
+++ b/firmware/comlib.c
@@ -95,6 +95,12 @@ unsigned char * com_readline()
 
             if(echo) {
                 printf(out_buf);
+                
+                // Temporary workaround buffer printing out previous char of
+                // previous input characters after a certain length.
+                // Real fix is to make sure all strings are properly null
+                // terminated. TODO
+                memset(out_buf, 0, 64);
             }
 
             if(!newline_found) {
@@ -103,7 +109,6 @@ unsigned char * com_readline()
             }
 
             cmd_ptr = 0;
-            out_buf = 0;
             
             usb_arm_out_endpoint(2);
             

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -93,8 +93,8 @@ int main(void)
     init();
     
     // MODE SELECT. Only one can be uncommented. TODO: Implement a config.h
-    //bitbang(); // Bitbang mode
-    programmer_at89();
+    bitbang(); // Bitbang mode
+    //programmer_at89();
     //glitch(); // future glitch mode
     // MODE SELECT END.
     

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -9,8 +9,9 @@
 #include <xc.h>
 #include <string.h>
 
-#include "modes/bitbang/bitbang.h"
+//#include "modes/bitbang/bitbang.h"
 //#include "modes/glitch/glitch.h"
+#include "modes/programmer/at89/at89.h"
 
 static inline void init(void) {
         unsigned int pll_startup = 600;
@@ -92,7 +93,8 @@ int main(void)
     init();
     
     // MODE SELECT. Only one can be uncommented. TODO: Implement a config.h
-    bitbang(); // Bitbang mode
+    //bitbang(); // Bitbang mode
+    programmer_at89();
     //glitch(); // future glitch mode
     // MODE SELECT END.
     

--- a/firmware/modes/programmer/at89/at89.c
+++ b/firmware/modes/programmer/at89/at89.c
@@ -5,13 +5,13 @@ static zif_bits_t gnd        = {0, 0, 0x8, 0, 0};
 static zif_bits_t vdd        = {0, 0, 0x4, 0, 0x80};
 static zif_bits_t vpp        = {0, 0, 0, 0x40, 0};
 
-inline void print_banner(void)
+static inline void print_banner(void)
 {
     com_println("   | |");
     com_println(" ==[+]==  open-tl866 Programmer Mode (AT89)");
     com_println("   | |");
 }
-inline void print_help(void)
+static inline void print_help(void)
 {
     com_println("\r\nCommands:\r\n  r <ADDR (hex)> [RANGE (hex)]\tRead from target");
     com_println("  w <ADDR (hex)> <BYTE (hex)>\tWrite to target");
@@ -23,7 +23,7 @@ inline void print_help(void)
     com_println("  h\t\t\t\tPrint help\r\n  v\t\t\t\tPrint version(s)");
 }
 
-inline void print_version()
+static inline void print_version()
 {
     // All these should be defined in some config header files. TODO
     com_println("Programmer Mode - AT89 version: 0.0.1");
@@ -32,7 +32,7 @@ inline void print_version()
 }
 
 // Neat trick taken from a stack overflow answer.
-inline unsigned char invert_bit_endianness(unsigned char byte)
+static inline unsigned char invert_bit_endianness(unsigned char byte)
 {
     static unsigned char lookup[16] = {
                             0x0, 0x8, 0x4, 0xc, 0x2, 0xa, 0x6, 0xe,
@@ -40,44 +40,44 @@ inline unsigned char invert_bit_endianness(unsigned char byte)
     return (lookup[byte & 0b1111] << 4) | lookup[byte >> 4];
 }
 
-inline void mask_p2_7(zif_bits_t op_base)
+static inline void mask_p2_7(zif_bits_t op_base)
 {
     op_base[3] |= 0x8;
 }
 
-inline void mask_p3_6(zif_bits_t op_base)
+static inline void mask_p3_6(zif_bits_t op_base)
 {
     op_base[1] |= 0x80;
 }
 
-inline void mask_p3_7(zif_bits_t op_base)
+static inline void mask_p3_7(zif_bits_t op_base)
 {
     op_base[2] |= 0x1;
 }
 
-inline void mask_xtal1(zif_bits_t op_base)
+static inline void mask_xtal1(zif_bits_t op_base)
 {
     op_base[2] |= 0x4;
 }
 
-inline void mask_prog(zif_bits_t op_base)
+static inline void mask_prog(zif_bits_t op_base)
 {
     op_base[3] |= 0x20;
 }
 
-inline void mask_addr(zif_bits_t op_base, unsigned int addr)
+static inline void mask_addr(zif_bits_t op_base, unsigned int addr)
 {
     op_base[0] = addr & 0xFF;
     op_base[2] |= (addr >> 8) << 4;
 }
 
-inline void mask_data(zif_bits_t op_base, unsigned char data)
+static inline void mask_data(zif_bits_t op_base, unsigned char data)
 {
     op_base[3] |= (data & 0x80);
     op_base[4] |= (invert_bit_endianness(data & 0x7f) >> 1);
 }
 
-inline unsigned char zif_to_data(zif_bits_t zif_state)
+static inline unsigned char zif_to_data(zif_bits_t zif_state)
 {
     // Filter the zif_bits response into a char byte with P0 bits
                    // Trim non-data ZIF pins    // Set the LSB of data byte
@@ -88,12 +88,12 @@ inline unsigned char zif_to_data(zif_bits_t zif_state)
 }
 
 // Flip clock pin directly from TL866
-inline void pin_flip_clock()
+static inline void pin_flip_clock()
 {
     PORTE ^= (1 << 2);
 }
 
-inline void print_zif_state(zif_bits_t op)
+static inline void print_zif_state(zif_bits_t op)
 {
     com_println("");
     com_println("01-08 09-16 17-24 25-32 33-40");
@@ -103,7 +103,7 @@ inline void print_zif_state(zif_bits_t op)
     com_println("");
 }
 
-inline void clock_write(zif_bits_t op, unsigned int cycles)
+static inline void clock_write(zif_bits_t op, unsigned int cycles)
 {
     zif_write(op);
     for(unsigned int i = 0; i <= cycles; i++) {
@@ -116,7 +116,7 @@ inline void clock_write(zif_bits_t op, unsigned int cycles)
 
 // Very slow, but useful for prototyping when other
 // pins need to be changed alongside the clock
-inline void zif_clock_write(zif_bits_t op_template, zif_bits_t op_clk,
+static inline void zif_clock_write(zif_bits_t op_template, zif_bits_t op_clk,
                             unsigned int cycles
                             )
 {
@@ -126,7 +126,7 @@ inline void zif_clock_write(zif_bits_t op_template, zif_bits_t op_clk,
     }
 }
 
-unsigned char read_byte(unsigned int addr)
+static unsigned char read_byte(unsigned int addr)
 {
     /* 
      * AT89C51 Read Pinout:
@@ -190,7 +190,7 @@ unsigned char read_byte(unsigned int addr)
     return zif_to_data(response);
 }
 
-void read(unsigned int addr, unsigned int range)
+static void read(unsigned int addr, unsigned int range)
 {    
     printf("%03X ", addr);
 
@@ -201,7 +201,7 @@ void read(unsigned int addr, unsigned int range)
     }
 }
 
-void write(unsigned int addr, unsigned char data)
+static void write(unsigned int addr, unsigned char data)
 {
     /* 
      * AT89C51 write Pinout:
@@ -274,7 +274,7 @@ void write(unsigned int addr, unsigned char data)
     printf("done.");
 }
 
-void erase()
+static void erase()
 {
     /* 
      * AT89C51 erase Pinout:
@@ -346,7 +346,7 @@ void erase()
 }
 
 // Does not work yet.
-void lock(unsigned char mode)
+static void lock(unsigned char mode)
 {
     /* 
      * AT89C51 lock (modes 2, 3, 4) Pinout:
@@ -430,7 +430,7 @@ void lock(unsigned char mode)
     printf("done.");
 }
 
-unsigned char read_sig(unsigned int offset)
+static unsigned char read_sig(unsigned int offset)
 {
    // TODO. Implements the signature reading routine as described in the
    // datasheet. Would be a good precheck before doign read/write/erase ops.
@@ -497,14 +497,14 @@ unsigned char read_sig(unsigned int offset)
     return zif_to_data(response);
 }
 
-bool sig_check()
+static bool sig_check()
 {
     if (read_sig(0) != 0x1E || read_sig(1) != 0x51 || read_sig(2) != 0xFF)
         return false;
     return true;
 }
 
-bool blank_check()
+static bool blank_check()
 {
     printf("Performing a blank-check... ");
     unsigned char data = 0;
@@ -522,7 +522,7 @@ bool blank_check()
     return true;
 }
 
-void self_test()
+static void self_test()
 {
     printf("Testing first 255 bytes...\r\n");
     erase();
@@ -546,7 +546,7 @@ void self_test()
     printf("\r\ndone.");
 }
 
-inline void eval_command(unsigned char * cmd)
+static inline void eval_command(unsigned char * cmd)
 {
     unsigned char * cmd_t = strtok(cmd, " ");
     switch (cmd_t[0]) {

--- a/firmware/modes/programmer/at89/at89.c
+++ b/firmware/modes/programmer/at89/at89.c
@@ -90,7 +90,7 @@ static inline unsigned char zif_to_data(zif_bits_t zif_state)
 // Flip clock pin directly from TL866
 static inline void pin_flip_clock()
 {
-    PORTE ^= (1 << 2);
+    PORTE ^= 0x4;
 }
 
 static inline void print_zif_state(zif_bits_t op)
@@ -329,7 +329,7 @@ static void erase()
     
     // Set PROG high before pulsing it low during erase
     zif_write(erase_preclk);
-    __delay_us(20);
+    __delay_ms(20);
     
     clock_write(erase_base, 48);
     
@@ -378,22 +378,27 @@ static void lock(unsigned char mode)
                         0b00100000,   // Busy signal (14)
                         0, 0, 0 };
 
+    print_zif_state(lock_base);
     switch (mode) {
         case 2:
+            printf("2\r\n");
             mask_p2_7(lock_base);
             mask_p3_6(lock_base);
             mask_p3_7(lock_base);
             break;
         case 3:
+            printf("3\r\n");
             mask_p2_7(lock_base);
             break;
         case 4:
+            printf("4\r\n");
             mask_p3_6(lock_base);
             break;
         default:
             printf("Invalid mode %u. Valid modes are 2, 3 or 4.", mode);
             return;
     }
+    print_zif_state(lock_base);
     // Set pin direction
     dir_write(dir);
     
@@ -414,6 +419,9 @@ static void lock(unsigned char mode)
     
     // Enable VPP right before setting the ZIF state
     vpp_en();
+    
+    print_zif_state(lock_base);
+    print_zif_state(lock_preclk);
     
     // Set PROG high before pulsing it low during erase
     zif_write(lock_preclk);

--- a/firmware/modes/programmer/at89/at89.c
+++ b/firmware/modes/programmer/at89/at89.c
@@ -9,7 +9,7 @@ inline void print_banner(void)
 inline void print_help(void)
 {
     com_println("\r\nCommands:\r\n  r <ADDR> [RANGE]\tRead from target");
-    com_println("  w <ADDR>\t\tWrite to target\r\n  e\t\t\tErase target");
+    com_println("  w <ADDR> <BYTE>\tWrite to target\r\n  e\t\t\tErase target");
     com_println("  h\t\t\tPrint help\r\n  v\t\t\tPrint version(s)\r\n");
 }
 

--- a/firmware/modes/programmer/at89/at89.c
+++ b/firmware/modes/programmer/at89/at89.c
@@ -121,7 +121,9 @@ void read_byte(unsigned int addr, unsigned int range)
                              0b00000000 };
 
     zif_bits_t read_clk;
-    for(unsigned int byte_idx = 0; byte_idx <= range; byte_idx++) {
+    
+    if (!range) { range = 1; }
+    for (unsigned int byte_idx = 0; byte_idx < range; byte_idx++) {
         // Mask in the address bits to the appropriate pins
         mask_addr(read_base, addr + byte_idx);
 

--- a/firmware/modes/programmer/at89/at89.c
+++ b/firmware/modes/programmer/at89/at89.c
@@ -8,8 +8,8 @@ inline void print_banner(void)
 }
 inline void print_help(void)
 {
-    com_println("\r\nCommands:\r\n  r\tRead from target");
-    com_println("  w\tWrite to target\r\n  e\tErase target");
+    com_println("\r\nCommands:\r\n  r <ADDR>\tRead from target");
+    com_println("  w <ADDR>\tWrite to target\r\n  e\tErase target");
     com_println("  h\tPrint help\r\n  v\tPrint version(s)\r\n");
 }
 
@@ -21,26 +21,6 @@ inline void print_version()
     com_println("");
 }
 
-void xfer_byte()
-{
-    // Setup pin direction
-    // dir_write();
-}
-
-
-void setup(unsigned char * cmd)
-{
-    com_println("\r\nUnimplemented.");
-}
-
-// TODO
-/*void or_pin(zif_bits_t &vdd, int pin_i)
-{
-    unsigned int byte = pin_i / 8;
-    unsigned int bit  = pin_i % 8;
-    vdd[byte] |= (char)1 >> bit;
-}*/
-
 void read_byte(unsigned char * cmd)
 {
     /* 
@@ -48,9 +28,9 @@ void read_byte(unsigned char * cmd)
      * 
      * Target   Dir     ZIF pin#    Programmer port
      * ------------------------------------------------------------------------
-     * RST      <-      09          RJ4 or Vdd_9            // (high)
+     * RST      <-      09          RJ4                     // (high)
      * PSEN     <-      29          RD7                     // (low)
-     * ALE      <-      30          RG0 or Vdd_30           // Pulsed prog.
+     * ALE      <-      30          RG0                     // (high)
      * EA       <-      31          RJ0                     // (high)
      * VCC      <-      40          Vdd_40
      * P0.{0-7) ->      39-32       RB{6,5,4,3,2}, RJ{3,2,1}      // PGM Data
@@ -66,17 +46,10 @@ void read_byte(unsigned char * cmd)
      * 
      */
     
-    // TODO: Actually use this
-    printf("\r\nAddress of requested byte? ");
-    int addr = atoi(com_readline());
-    printf("\r\naddr = %i\r\n", addr);
-
-    zif_bits_t zbits_null = {   0b00000000,
-                                0b00000000,
-                                0b00000000,
-                                0b00000000,
-                                0b00000000 };
+    unsigned int addr = atoi(strtok(NULL, " "));
     
+    printf("\r\n%u", addr);
+
     zif_bits_t dir = {  0,
                         0b00100000,   // Busy signal (14)
                         0,
@@ -90,86 +63,299 @@ void read_byte(unsigned char * cmd)
                         0b00001000,   // GND (20)
                         0, 0 };
 
+    // Set pin direction
+    dir_write(dir);
+    
+    // Set Vdd / GND pinout  
+    set_vdd(vdd);
+    set_gnd(gnd);
+    
+    // Setting voltages
+    vdd_val(5); // 5.0 v - 5.2 v
+    
+    zif_bits_t input_byte = {0,0,0,0,0};
+    
+    zif_bits_t read_clk0 =     {        0b00000000,
+                                        0b10000001, // 3.6 ctrl (16), RST (9)
+                                        0b00000001, // 3.7 ctrl (17) 
+                                        0b01100000, // EA (31), ALE (30)
+                                        0b00000000 };
+
+    zif_bits_t read_clk1;
+    memcpy(read_clk1, read_clk0, sizeof read_clk1);
+    read_clk1[2] = read_clk0[2] | 0b00000100;
+    
+    zif_bits_t read_setup_clk1_d =     {  0b00000000,
+                                        0b10000001, // 3.6 ctrl (16), RST (9)
+                                        0b00000101, // XTAL1 (19), 3.7 ctrl (17)
+                                        0b01100000, // EA (31), ALE (30)
+                                        0b00000000 };
+    
+    // Mask the addrs in
+    read_clk0[0] = addr & 255;
+    read_clk0[2] = (addr >> 8) << 4 | read_clk0[2];
+    
+    read_clk1[0] = addr & 255;
+    read_clk1[2] = (addr >> 8) << 4 | read_clk1[2];
+    
+    for(unsigned char i = 0; i <= 48; i++) {
+        zif_write(read_clk0); // Maybe better flip XTAL1 directly than to
+                                    // call zif_write every time. TODO
+        zif_write(read_clk1);
+    }
+    
+    zif_read(input_byte);
+    
+    zif_write(zbits_null);
+    
+    unsigned char byte;
+    {
+        static unsigned char lookup[16] = {
+                            0x0, 0x8, 0x4, 0xc, 0x2, 0xa, 0x6, 0xe,
+                            0x1, 0x9, 0x5, 0xd, 0x3, 0xb, 0x7, 0xf, };
+    
+        // Filter the zif_bits response into a char byte with P0 bits
+        byte = (input_byte[4] << 1) | !! (input_byte[3] & (1 << 7));
+        
+        // Invert bit-endianness
+        byte = (lookup[byte&0b1111] << 4) | lookup[byte>>4];
+    }
+
+    printf(" %02X\r\n", byte );
+}
+
+void write_byte(unsigned char * cmd)
+{
+    /* 
+     * AT89C51 write Pinout:
+     * 
+     * Target   Dir     ZIF pin#    Programmer port
+     * ------------------------------------------------------------------------
+     * RST      <-      09          RJ4                     // (high)
+     * PSEN     <-      29          RD7                     // (low)
+     * PROG      <-      30          RG0                     // Pulsed prog.
+     * VPP       <-      31          VPP_31                  // 12v
+     * VCC      <-      40          Vdd_40
+     * P0.{0-7) <-      39-32       RB{6,5,4,3,2}, RJ{3,2,1}      // PGM Data
+     * P1.{0-7} <-      1-8         RC{5,4,3,2}, RJ{7,6}, RC{6,7} // Addr
+     * P2.{0-3} <-      21-24       RE{4,5,6,1}             // Addr (contd.)
+     * P2.6     <-      27          RD5                     // ctrl (low)
+     * P2.7     <-      28          RD6                     // ctrl (high)
+     * P3.4     ->      14          RD1                     // Busy
+     * P3.6     <-      16          RG1                     // ctrl (high)
+     * P3.7     <-      17          RE0                     // ctrl (high)
+     * >
+     * 
+     * 
+     */
+    
+    unsigned int addr  = atoi(strtok(NULL, " "));
+    unsigned char byte = atoi(strtok(NULL, " "));
+    
+    printf("\r\nWriting byte %x at address %x\r\n", byte, addr);
+
+    zif_bits_t dir = {  0,
+                        0b00100000,   // Busy signal (14)
+                        0, 0, 0 };
+    
+    zif_bits_t vdd = {  0, 0, 0, 0,
+                        0b10000000 }; // VDD (40)
+
+    zif_bits_t vpp = {  0, 0, 0,
+                        0b01000000,   // VPP (31)
+                        0 };
+    
+    zif_bits_t gnd = {  0, 0,
+                        0b00001000,   // GND (20)
+                        0, 0 };
+
     printf("Setting pin direction.\r\n");
     dir_write(dir);
     
     printf("Setting pins.\r\n");  
     set_vdd(vdd);
+    set_vpp(vpp);
     set_gnd(gnd);
     
     printf("Setting voltages.\r\n");
     vdd_val(5); // 5.0 v - 5.2 v
+    vpp_val(1); // 12.8 - 13.2
     
-    printf("Press ENTER when ready.");
+    zif_bits_t write_preclk =   { 0b00000000,
+                                  0b10000001, // 3.6 ctrl (16), RST (9)
+                                  0b00000101, // XTAL1 (19), 3.7 ctrl (17)
+                                  0b01101000, // VPP (31), PROG (30), 2.7 (28)
+                                  0b00000000 };
+
+    zif_bits_t write_clk0 =     { 0b00000000,
+                                  0b10000001, // 3.6 ctrl (16), RST (9)
+                                  0b00000001, // 3.7 ctrl (17) 
+                                  0b01001000, // VPP (31), 2.7 (28)
+                                  0b00000000 };
+
+    zif_bits_t write_clk1 =     { 0b00000000,
+                                  0b10000001, // 3.6 ctrl (16), RST (9)
+                                  0b00000101, // XTAL1 (19), 3.7 ctrl (17)
+                                  0b01001000, // VPP (31), 2.7 (28)
+                                  0b00000000 };
     
-    com_readline();
+    // Mask address bits
+    write_clk0[0] = addr & 255;
+    write_clk0[2] = (addr >> 8) << 4 | write_clk0[2];
     
-    zif_bits_t read_setup_clk0 =     {   0b00000000,
-                                    0b10000001, // 3.6 ctrl (16), RST (9)
-                                    0b00000001, // 3.7 ctrl (17) 
-                                    0b01100000, // EA (31), ALE (30)
-                                    0b00000000 };
+    write_clk1[0] = addr & 255;
+    write_clk1[2] = (addr >> 8) << 4 | write_clk1[2];
     
-    zif_bits_t read_setup_clk1 =     {   0b00000000,
-                                    0b10000001, // 3.6 ctrl (16), RST (9)
-                                    0b00000101, // XTAL1 (19), 3.7 ctrl (17)
-                                    0b01100000, // EA (31), ALE (30)
-                                    0b00000000 };
+    write_preclk[0] = addr & 255;
+    write_preclk[2] = (addr >> 8) << 4 | write_preclk[2];
+
+    // Mask data bits
+    {
+        static unsigned char lookup[16] = {
+                            0x0, 0x8, 0x4, 0xc, 0x2, 0xa, 0x6, 0xe,
+                            0x1, 0x9, 0x5, 0xd, 0x3, 0xb, 0x7, 0xf, };
+        
+        unsigned char mask_4 = byte & 127;
+        unsigned char mask_sw_4 = (lookup[mask_4 & 0b1111] << 4) | lookup[mask_4 >> 4];
+        
+        write_clk0[3] = (byte & 128) | write_clk0[3];
+        write_clk0[4] = (mask_sw_4 >> 1) | write_clk0[4];
+
+        write_clk1[3] = (byte & 128) | write_clk1[3]; 
+        write_clk1[4] = (mask_sw_4 >> 1) | write_clk1[4];
+        
+        write_preclk[3] = (byte & 128) | write_preclk[3]; 
+        write_preclk[4] = (mask_sw_4 >> 1) | write_preclk[4];
+    }
+
+    vpp_en();
     
-    for(unsigned int i = 65525; i > 0; i--) {
-        zif_write(read_setup_clk0); // Better flip XTAL1 directly than to
+    zif_write(write_preclk);
+    
+    __delay_us(20);
+
+    for(unsigned char i = 0; i <= 48; i++) {
+        zif_write(write_clk0); // Better flip XTAL1 directly than to
                                     // call zif_write every time.
         
-        zif_write(read_setup_clk1);
+        zif_write(write_clk1);
     }
     
-    printf("Done.\r\n");
+    vpp_dis();
     
     zif_write(zbits_null);
 }
 
-void write(unsigned char * cmd)
-{
-    switch (cmd[1]) {
-        
-    }
-}
-
 void erase(unsigned char * cmd)
 {
-    switch (cmd[1]) {
+    /* 
+     * AT89C51 erase Pinout:
+     * 
+     * Target   Dir     ZIF pin#    Programmer port
+     * ------------------------------------------------------------------------
+     * RST      <-      09          RJ4                     // (high)
+     * PSEN     <-      29          RD7                     // (low)
+     * ALE      <-      30          RG0                     // Pulsed erase
+     * VPP       <-      31          VPP_31                  // 12v
+     * VCC      <-      40          Vdd_40
+     * P2.6     <-      27          RD5                     // ctrl (high)
+     * P2.7     <-      28          RD6                     // ctrl (low)
+     * P3.4     ->      14          RD1                     // Busy
+     * P3.6     <-      16          RG1                     // ctrl (low)
+     * P3.7     <-      17          RE0                     // ctrl (low)
+     * >
+     */
+    
+    zif_bits_t dir = {  0,
+                        0b00100000,   // Busy signal (14)
+                        0, 0, 0 };
+    
+    zif_bits_t vdd = {  0, 0, 0, 0,
+                        0b10000000 }; // VDD (40)
+
+    zif_bits_t vpp = {  0, 0, 0,
+                        0b01000000,   // VPP (31)
+                        0 };
+    
+    zif_bits_t gnd = {  0, 0,
+                        0b00001000,   // GND (20)
+                        0, 0 };
+
+    // Setting pin direction
+    dir_write(dir);
+    
+    // Setting pins
+    set_vdd(vdd);
+    set_vpp(vpp);
+    set_gnd(gnd);
+    
+    // Setting voltages
+    vdd_val(5); // 5.0 v - 5.2 v
+    vpp_val(1); // 12.8 - 13.2
+    
+    zif_bits_t erase_preclk =     {     0b00000000,
+                                        0b00000001, // RST (9)
+                                        0b00000100, // XTAL1 (19)
+                                        0b01100100, // VPP (31), PROG (30), 2.6 (27)
+                                        0b00000000 };
+    
+    zif_bits_t erase_clk0 =     {       0b00000000,
+                                        0b00000001, // RST (9)
+                                        0b00000000,  
+                                        0b01000100, // VPP (31), 2.6 (27)
+                                        0b00000000 };
+
+    zif_bits_t erase_clk1 =     {       0b00000000,
+                                        0b00000001, // RST (9)
+                                        0b00000100, // XTAL1 (19)
+                                        0b01000100, // VPP (31), 2.6 (27)
+                                        0b00000000 };
+    
+    vpp_en();
+    
+    zif_write(erase_preclk);
+    
+    __delay_us(20);
+    
+    for(unsigned char i = 0; i <= 48; i++) {
+        zif_write(erase_clk0); // Better flip XTAL1 directly than to
+                                    // call zif_write every time.
         
+        zif_write(erase_clk1);
     }
+    
+    vpp_dis();
+    
+    zif_write(zbits_null);
+    
+    printf("\r\nErased.\r\n");
+    
+    
 }
 
 void verify(unsigned char * cmd)
 {
-    switch (cmd[1]) {
-        
-    }
+    printf("\r\nUnimplemented.\r\n");
 }
 
 inline void eval_command(unsigned char * cmd)
 {
-    switch (cmd[0]) {
-        case 's':
-            setup(cmd);
-            break;
-            
+    unsigned char * cmd_t = strtok(cmd, " ");
+    switch (cmd_t[0]) {
         case 'r':
-            read_byte(cmd);
+            read_byte(cmd_t);
             break;
             
         case 'w':
-            write(cmd);
+            write_byte(cmd_t);
             break;
             
         case 'e':
-            erase(cmd);
+            erase(cmd_t);
             break;
 
         case 'v':
-            verify(cmd);
+            verify(cmd_t);
             break;
             
         case '?':

--- a/firmware/modes/programmer/at89/at89.c
+++ b/firmware/modes/programmer/at89/at89.c
@@ -1,0 +1,204 @@
+#include "at89.h"
+
+inline void print_banner(void)
+{
+    com_println("   | |");
+    com_println(" ==[+]==  open-tl866 Programmer Mode (AT89)");
+    com_println("   | |");
+}
+inline void print_help(void)
+{
+    com_println("\r\nCommands:\r\n  r\tRead from target");
+    com_println("  w\tWrite to target\r\n  e\tErase target");
+    com_println("  h\tPrint help\r\n  v\tPrint version(s)\r\n");
+}
+
+inline void print_version()
+{
+    // All these should be defined in some config header files. TODO
+    com_println("Programmer Mode - AT89 version: 0.0.1");
+    com_println("open-tl866 lib version: UNIMPLEMENTED");
+    com_println("");
+}
+
+void xfer_byte()
+{
+    // Setup pin direction
+    // dir_write();
+}
+
+
+void setup(unsigned char * cmd)
+{
+    com_println("\r\nUnimplemented.");
+}
+
+// TODO
+/*void or_pin(zif_bits_t &vdd, int pin_i)
+{
+    unsigned int byte = pin_i / 8;
+    unsigned int bit  = pin_i % 8;
+    vdd[byte] |= (char)1 >> bit;
+}*/
+
+void read_byte(unsigned char * cmd)
+{
+    /* 
+     * AT89C51 Read Pinout:
+     * 
+     * Target   Dir     ZIF pin#    Programmer port
+     * ------------------------------------------------------------------------
+     * RST      <-      09          RJ4 or Vdd_9            // (high)
+     * PSEN     <-      29          RD7                     // (low)
+     * ALE      <-      30          RG0 or Vdd_30           // Pulsed prog.
+     * EA       <-      31          RJ0                     // (high)
+     * VCC      <-      40          Vdd_40
+     * P0.{0-7) ->      39-32       RB{6,5,4,3,2}, RJ{3,2,1}      // PGM Data
+     * P1.{0-7} <-      1-8         RC{5,4,3,2}, RJ{7,6}, RC{6,7} // Addr
+     * P2.{0-3} <-      21-24       RE{4,5,6,1}             // Addr (contd.)
+     * P2.6     <-      27          RD5                     // ctrl (low)
+     * P2.7     <-      28          RD6                     // ctrl (low)
+     * P3.4     ->      14          RD1                     // Busy
+     * P3.6     <-      16          RG1                     // ctrl (high)
+     * P3.7     <-      17          RE0                     // ctrl (high)
+     * >
+     * 
+     * 
+     */
+    
+    // TODO: Actually use this
+    printf("\r\nAddress of requested byte? ");
+    int addr = atoi(com_readline());
+    printf("\r\naddr = %i\r\n", addr);
+
+    zif_bits_t zbits_null = {   0b00000000,
+                                0b00000000,
+                                0b00000000,
+                                0b00000000,
+                                0b00000000 };
+    
+    zif_bits_t dir = {  0,
+                        0b00100000,   // Busy signal (14)
+                        0,
+                        0b10000000,   // p0.7 (32)
+                        0b01111111 }; // p0.{6-0} (33-39)  
+    
+    zif_bits_t vdd = {  0, 0, 0, 0,
+                        0b10000000 }; // VDD (40)
+    
+    zif_bits_t gnd = {  0, 0,
+                        0b00001000,   // GND (20)
+                        0, 0 };
+
+    printf("Setting pin direction.\r\n");
+    dir_write(dir);
+    
+    printf("Setting pins.\r\n");  
+    set_vdd(vdd);
+    set_gnd(gnd);
+    
+    printf("Setting voltages.\r\n");
+    vdd_val(5); // 5.0 v - 5.2 v
+    
+    printf("Press ENTER when ready.");
+    
+    com_readline();
+    
+    zif_bits_t read_setup_clk0 =     {   0b00000000,
+                                    0b10000001, // 3.6 ctrl (16), RST (9)
+                                    0b00000001, // 3.7 ctrl (17) 
+                                    0b01100000, // EA (31), ALE (30)
+                                    0b00000000 };
+    
+    zif_bits_t read_setup_clk1 =     {   0b00000000,
+                                    0b10000001, // 3.6 ctrl (16), RST (9)
+                                    0b00000101, // XTAL1 (19), 3.7 ctrl (17)
+                                    0b01100000, // EA (31), ALE (30)
+                                    0b00000000 };
+    
+    for(unsigned int i = 65525; i > 0; i--) {
+        zif_write(read_setup_clk0); // Better flip XTAL1 directly than to
+                                    // call zif_write every time.
+        
+        zif_write(read_setup_clk1);
+    }
+    
+    printf("Done.\r\n");
+    
+    zif_write(zbits_null);
+}
+
+void write(unsigned char * cmd)
+{
+    switch (cmd[1]) {
+        
+    }
+}
+
+void erase(unsigned char * cmd)
+{
+    switch (cmd[1]) {
+        
+    }
+}
+
+void verify(unsigned char * cmd)
+{
+    switch (cmd[1]) {
+        
+    }
+}
+
+inline void eval_command(unsigned char * cmd)
+{
+    switch (cmd[0]) {
+        case 's':
+            setup(cmd);
+            break;
+            
+        case 'r':
+            read_byte(cmd);
+            break;
+            
+        case 'w':
+            write(cmd);
+            break;
+            
+        case 'e':
+            erase(cmd);
+            break;
+
+        case 'v':
+            verify(cmd);
+            break;
+            
+        case '?':
+        case 'h':
+            print_help();
+            break;
+        case 'V':
+            print_version();
+            break;
+        default:
+            printf("\r\nError: Unknown command.\r\n");
+    }
+}
+
+int programmer_at89(void) {
+    
+    // Wait for user interaction (press enter).
+    com_readline();
+    
+    print_banner();
+    print_help();
+    enable_echo();
+    
+    unsigned char * cmd;
+    
+    while(1) {
+        printf("CMD> ");
+        cmd = com_readline();
+        eval_command(cmd);
+    }
+    
+}

--- a/firmware/modes/programmer/at89/at89.c
+++ b/firmware/modes/programmer/at89/at89.c
@@ -1,9 +1,9 @@
 #include "at89.h"
 
 static zif_bits_t zbits_null = {0, 0, 0, 0, 0};
-static zif_bits_t gnd        = {0, 0, 8, 0, 0};
-static zif_bits_t vdd        = {0, 0, 4, 0, 128};
-static zif_bits_t vpp        = {0, 0, 0, 64, 0};
+static zif_bits_t gnd        = {0, 0, 0x8, 0, 0};
+static zif_bits_t vdd        = {0, 0, 0x4, 0, 0x80};
+static zif_bits_t vpp        = {0, 0, 0, 0x40, 0};
 
 inline void print_banner(void)
 {

--- a/firmware/modes/programmer/at89/at89.c
+++ b/firmware/modes/programmer/at89/at89.c
@@ -71,7 +71,7 @@ inline void zif_clock_write(zif_bits_t op_template, zif_bits_t op_clk,
     }
 }
 
-void read_byte(unsigned char * cmd)
+void read_byte(unsigned int addr, unsigned int range)
 {
     /* 
      * AT89C51 Read Pinout:
@@ -93,7 +93,6 @@ void read_byte(unsigned char * cmd)
      * P3.7     <-      17          RE0                     // ctrl (high)
      */
     
-    unsigned int addr = atoi(strtok(NULL, " "));
     printf("\r\n%u", addr);
 
     // Set pin direction
@@ -142,7 +141,7 @@ void read_byte(unsigned char * cmd)
     printf(" %02X\r\n", zif_to_addr(input_byte) );
 }
 
-void write_byte(unsigned char * cmd)
+void write_byte(unsigned int addr, unsigned char data)
 {
     /* 
      * AT89C51 write Pinout:
@@ -163,9 +162,6 @@ void write_byte(unsigned char * cmd)
      * P3.6     <-      16          RG1                     // ctrl (high)
      * P3.7     <-      17          RE0                     // ctrl (high)
      */
-    
-    unsigned int addr  = atoi(strtok(NULL, " "));
-    unsigned char data = atoi(strtok(NULL, " "));
 
     // Set pin direction
     zif_bits_t dir = {  0,
@@ -221,7 +217,7 @@ void write_byte(unsigned char * cmd)
     printf("\r\nWrote byte %x at address %x\r\n", data, addr);
 }
 
-void erase(unsigned char * cmd)
+void erase()
 {
     /* 
      * AT89C51 erase Pinout:
@@ -302,15 +298,23 @@ inline void eval_command(unsigned char * cmd)
     unsigned char * cmd_t = strtok(cmd, " ");
     switch (cmd_t[0]) {
         case 'r':
-            read_byte(cmd_t);
+        {
+            unsigned int addr  = atoi(strtok(NULL, " "));
+            unsigned int range = atoi(strtok(NULL, " "));
+            read_byte(addr, range);
             break;
+        }
             
         case 'w':
-            write_byte(cmd_t);
+        {
+            unsigned int addr  = atoi(strtok(NULL, " "));
+            unsigned char data = atoi(strtok(NULL, " "));
+            write_byte(addr, data);
             break;
+        }
             
         case 'e':
-            erase(cmd_t);
+            erase();
             break;
 
         case 'v':

--- a/firmware/modes/programmer/at89/at89.h
+++ b/firmware/modes/programmer/at89/at89.h
@@ -1,0 +1,13 @@
+#ifndef AT89_H
+#define AT89_H
+
+#include <xc.h>
+#include <string.h>
+#include "usb.h"
+#include "../../../system.h"
+#include "../../../comlib.h"
+#include "../../../parse.h"
+
+int programmer_at89(void);
+
+#endif

--- a/firmware/modes/programmer/at89/at89.h
+++ b/firmware/modes/programmer/at89/at89.h
@@ -8,8 +8,17 @@
 #include "../../../comlib.h"
 #include "../../../parse.h"
 
-zif_bits_t zbits_null = { 0 };
 
+#define ZIFMASK_XTAL1 4;
+#define ZIFMASK_GND 8;
+#define ZIFMASK_VDD 128;
+#define ZIFMASK_VPP 64;
+#define ZIFMASK_PROG 32;
+
+zif_bits_t zbits_null = {0, 0, 0, 0, 0};
+zif_bits_t gnd        = {0, 0, 8, 0, 0};
+zif_bits_t vdd        = {0, 0, 0, 0, 128};
+zif_bits_t vpp        = {0, 0, 0, 64, 0};
 
 int programmer_at89(void);
 

--- a/firmware/modes/programmer/at89/at89.h
+++ b/firmware/modes/programmer/at89/at89.h
@@ -15,11 +15,6 @@
 #define ZIFMASK_VPP 64;
 #define ZIFMASK_PROG 32;
 
-zif_bits_t zbits_null = {0, 0, 0, 0, 0};
-zif_bits_t gnd        = {0, 0, 8, 0, 0};
-zif_bits_t vdd        = {0, 0, 0, 0, 128};
-zif_bits_t vpp        = {0, 0, 0, 64, 0};
-
 int programmer_at89(void);
 
 #endif

--- a/firmware/modes/programmer/at89/at89.h
+++ b/firmware/modes/programmer/at89/at89.h
@@ -8,6 +8,9 @@
 #include "../../../comlib.h"
 #include "../../../parse.h"
 
+zif_bits_t zbits_null = { 0 };
+
+
 int programmer_at89(void);
 
 #endif

--- a/firmware/nbproject/configurations.xml
+++ b/firmware/nbproject/configurations.xml
@@ -13,6 +13,11 @@
         <logicalFolder name="f1" displayName="bitbang" projectFiles="true">
           <itemPath>modes/bitbang/bitbang.h</itemPath>
         </logicalFolder>
+        <logicalFolder name="f2" displayName="programmer" projectFiles="true">
+          <logicalFolder name="f1" displayName="at89" projectFiles="true">
+            <itemPath>modes/programmer/at89/at89.h</itemPath>
+          </logicalFolder>
+        </logicalFolder>
       </logicalFolder>
       <logicalFolder name="f2" displayName="usb" projectFiles="true">
         <itemPath>usb/usb_config.h</itemPath>
@@ -39,6 +44,11 @@
       <logicalFolder name="f3" displayName="modes" projectFiles="true">
         <logicalFolder name="f1" displayName="bitbang" projectFiles="true">
           <itemPath>modes/bitbang/bitbang.c</itemPath>
+        </logicalFolder>
+        <logicalFolder name="f2" displayName="programmer" projectFiles="true">
+          <logicalFolder name="f1" displayName="at89" projectFiles="true">
+            <itemPath>modes/programmer/at89/at89.c</itemPath>
+          </logicalFolder>
         </logicalFolder>
       </logicalFolder>
       <logicalFolder name="f2" displayName="usb" projectFiles="true">


### PR DESCRIPTION
Most functions work and tested, but some parts could be optimized, cleaned, and a few warning should be attended to. Will get to these items later.

I am unable to test setting the lock bits, but I'm unsure whether it's an issue with my code or with my batch of AT89C51s. I don't have a spare programmer to isolated this issue right now, so maybe someone else could give it a run.

In order to us the AT89C51 programmer, don't forget to comment the bitbang mode function entrypoint and include declaration in main.c, and uncomment the at89 function and include. I'm leaving main.c alone until someone tells me that it's ok otherwise.