### PR TITLE
Fix pytl866 module install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ The Python client library provides a command-line client for the stock
 bootloader which can be used to flash any firmware to the TL866.
 To install the CLI tool, run:
 
-```python pytl866/setup.py install```
-
+```cd pytl866 && python3 setup.py install```
 
 ### Resetting to the Bootloader
 

--- a/pytl866/setup.py
+++ b/pytl866/setup.py
@@ -10,7 +10,7 @@ setup(
     author="William D. Jones",
     author_email="thor0505@comcast.net",
     license="BSD",
-    packages=["pytl866"],
+    packages=["pytl866", "pytl866/bootloader"],
     install_requires=[
         "intelhex",
         "pyserial",


### PR DESCRIPTION
Tested with Python 3.6 on Linux. Using the old instructions created and installed an egg with no content.