### PR TITLE
[RFC] Add Linux udev rule for the opentl866 serial device

### DIFF
--- a/contrib/96-opentl866.rules
+++ b/contrib/96-opentl866.rules
@@ -1,0 +1,11 @@
+# udev rules for OpenTL866 programmers
+#
+# Symlinks the serial device the programmer binds to to /dev/tl866
+# If you plan to have several devices attached, switched to the numbered device rule below
+
+ACTION!="add", GOTO="tl866_end"
+
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="8661", SYMLINK+="tl866", GROUP="adm"
+# ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="8661", SYMLINK+="tl866_%n", GROUP="adm"
+
+LABEL="tl866_end"

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,5 @@
+96-opentl866.rules: udev rules for opentl866 serial device
+
+    Copy this to your Linux udev rules.d directory (usually
+    /lib/udev/rules.d/) and restart the udev service to get a
+    /dev/tl866 link that is usable by users in the "adm" group.


### PR DESCRIPTION
udev rule made for my own Ubuntu use. Creates a /dev/tl866 link pointed at whatever serial device the programmer ends up at. Also sets the the group to "adm" which happens to work out well on Ubuntu because that's the group the use installing the OS gets added to when he gets sudo access.

RFC: is "contrib" a good directory name for stuff like this? I considered "extra" first, but that mucks up completion of ht "extern" directory.