### PR TITLE
Improve the udev rules file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Your output will be available under `dist/default/production/firmware.production
 3. If changing any project options (right-click Project name and select "Properties") or adding new source files (right-click Source Files logical folder and click "New" or "Add Existing"), make sure to commit any changes to `nbproject/*.xml` files to the repository.
 The [correct files](http://microchipdeveloper.com/faq:72) are already under version control.
 
+## Device Drivers and Configuration
+
+On Linux systems, the udev rules file `contrib/96-opentl866.rules`
+should be copied into `/etc/udev/rules.d/`. Doing so will allow non-root
+users who are members of the `plugdev` group to access the devices. Once
+the rules file is installed udev needs to be reloaded. On modern Linux
+systems that use systemd that can be done by running:
+
+```sudo systemctl restart systemd-udevd```
+
 ## Programming
 
 The Python client library provides a command-line client for the stock

--- a/contrib/96-opentl866.rules
+++ b/contrib/96-opentl866.rules
@@ -1,11 +1,22 @@
 # udev rules for OpenTL866 programmers
 #
-# Symlinks the serial device the programmer binds to to /dev/tl866
-# If you plan to have several devices attached, switched to the numbered device rule below
 
 ACTION!="add", GOTO="tl866_end"
 
-ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="8661", SYMLINK+="tl866", GROUP="adm"
-# ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="8661", SYMLINK+="tl866_%n", GROUP="adm"
+# Symlinks the serial device the programmer binds to to /dev/tl866
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="8661", SYMLINK+="tl866", GROUP="plugdev", MODE="0660"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="8662", SYMLINK+="tl866", GROUP="plugdev", MODE="0660"
+
+# If you plan to have several devices attached use these rules instead of the above.
+#SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="8661", SYMLINK+="tl866_%n", GROUP="plugdev", MODE="0660"
+#SUBSYSTEM=="tty", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="8662", SYMLINK+="tl866_%n", GROUP="plugdev", MODE="0660"
+
+
+# TL866A / TL866CS stock firmware
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="e11c", GROUP="plugdev", MODE="0660"
+
+# TL866II PLUS stock firmware
+SUBSYSTEM=="usb", ATTRS{idVendor}=="a466", ATTRS{idProduct}=="0a53", GROUP="plugdev", MODE="0660"
+
 
 LABEL="tl866_end"


### PR DESCRIPTION
Switches the group from adm to plugdev and adds support for more devices. Also adds instructions to the README.

I've tested the rules for the TL866 A/CS on both the stock and open firmware, including the numbered alternate rules. I only tested the TL866II PLUS with the stock firmware as it doesn't support the open firmware yet.