### PR TITLE
CMake Windows Improvements

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -25,6 +25,9 @@ target_sources(core INTERFACE
     ${CMAKE_SOURCE_DIR}/usb/usb_descriptors.c
 )
 
+# On Windows, xc8 can't find io.h, and _only_ io.h, without this path added. Compiler bug?
+target_include_directories(core INTERFACE ${CMAKE_SOURCE_DIR})
+
 # set linker options to support the bootloader
 target_link_libraries(core INTERFACE
     # reserve the bootloader code area


### PR DESCRIPTION
Creating a PR as requested by @JohnDMcMaster:

This PR fixes the following issues:

* On Windows only, `io.h` is not found unless `firmware` is added to the include path.
* Update `cmake-microchip` submodule to improve compiler autodetection on Windows.