### PR TITLE
ezzif: high level API + test app

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(core INTERFACE
 
     ${CMAKE_SOURCE_DIR}/comlib.c
     ${CMAKE_SOURCE_DIR}/configuration_bits.c
+    ${CMAKE_SOURCE_DIR}/ezzif.c
     ${CMAKE_SOURCE_DIR}/io.c
     ${CMAKE_SOURCE_DIR}/parse.c
     ${CMAKE_SOURCE_DIR}/stock_compat.c
@@ -64,6 +65,10 @@ endfunction()
 
 add_tl866_mode(tl866-bitbang
     ${CMAKE_SOURCE_DIR}/modes/bitbang/bitbang.c
+)
+
+add_tl866_mode(tl866-ezzif
+    ${CMAKE_SOURCE_DIR}/modes/ezzif/main.c
 )
 
 add_tl866_mode(tl866-at89

--- a/firmware/comlib.h
+++ b/firmware/comlib.h
@@ -17,4 +17,9 @@ unsigned char * com_readline();
 void com_print(const char * str);
 void com_println(const char * str);
 
+//xc18 can't handle 
+//#define com_printfln(s, ...) printf(s "\r\n", __VA_ARGS__)
+
+extern unsigned comblib_drops;
+
 #endif

--- a/firmware/ezzif.c
+++ b/firmware/ezzif.c
@@ -1,0 +1,287 @@
+#include "ezzif.h"
+#include "comlib.h"
+
+#include <string.h>
+#include <stdio.h>
+
+//Direction
+zif_bits_t ezzif_zbd = {0};
+//Output
+zif_bits_t ezzif_zbo = {0};
+zif_bits_t ezzif_zb_vpp = {0};
+zif_bits_t ezzif_zb_vdd = {0};
+zif_bits_t ezzif_zb_gnd = {0};
+
+const_zif_bits_t ezzif_zero = {0, 0, 0, 0, 0};
+
+static int has_error = 0;
+
+//Verify no pin has two drivers
+int is_vsafe(void) {
+    for (unsigned i = 0; i < 5; ++i) {
+        unsigned char checks[4];
+
+        checks[0] = ezzif_zbd[i];
+        checks[1] = ezzif_zb_vpp[i];
+        checks[2] = ezzif_zb_vdd[i];
+        checks[3] = ezzif_zb_gnd[i];
+
+        for (unsigned j = 0; j < sizeof(checks); ++j) {
+            for (unsigned k = 0; k < sizeof(checks); ++k) {
+                if (j != k && (checks[i] & checks[j])) {
+                    has_error = 1;
+                    return 0;
+                }
+            }
+        }
+
+    }
+    return 1;
+}
+
+void ezzif_reset(void) {
+    //ezzif_zbd = {0};
+    memset(ezzif_zbd, 0, sizeof(ezzif_zbd));
+    dir_write(ezzif_zbd);
+
+    memset(ezzif_zbo, 0, sizeof(ezzif_zbo));
+    zif_write(ezzif_zbo);
+
+    ezzif_reset_vpp();
+    ezzif_reset_vdd();
+    ezzif_reset_gnd();
+
+    //Make sure?
+    for (unsigned i = 0; i < 8; ++i) {
+        write_latch(i, 0x00);
+    }
+}
+
+void ezzif_reset_vpp(void) {
+    memset(ezzif_zb_vpp, 0, sizeof(ezzif_zb_vpp));
+    set_vpp(ezzif_zb_vpp);
+    vpp_dis();
+}
+
+void ezzif_reset_vdd(void) {
+    memset(ezzif_zb_vdd, 0, sizeof(ezzif_zb_vdd));
+    set_vdd(ezzif_zb_vdd);
+    vdd_dis();
+}
+
+void ezzif_reset_gnd(void) {
+    memset(ezzif_zb_gnd, 0, sizeof(ezzif_zb_gnd));
+    set_gnd(ezzif_zb_gnd);
+}
+
+int ezzif_error(void) {
+    int ret = has_error;
+    has_error = 0;
+    return ret;
+}
+
+void ezzif_print_debug(void) {
+    port_bits_t p_bits;
+
+    printf("ezzif state\r\n");
+    printf("  ezzif error: %d\r\n", has_error);
+    printf("  comlib drops: %u\r\n", comblib_drops);
+    printf("\r\n");
+
+    printf("  ezzif dir %02X %02X %02X %02X %02X\r\n",
+            ezzif_zbd[0], ezzif_zbd[1], ezzif_zbd[2], ezzif_zbd[3], ezzif_zbd[4]);
+    printf("  ezzif out %02X %02X %02X %02X %02X\r\n",
+            ezzif_zbo[0], ezzif_zbo[1], ezzif_zbo[2], ezzif_zbo[3], ezzif_zbo[4]);
+    printf("  ezzif VPP %02X %02X %02X %02X %02X\r\n",
+            ezzif_zb_vpp[0], ezzif_zb_vpp[1], ezzif_zb_vpp[2], ezzif_zb_vpp[3], ezzif_zb_vpp[4]);
+    printf("  ezzif VDD %02X %02X %02X %02X %02X\r\n",
+            ezzif_zb_vdd[0], ezzif_zb_vdd[1], ezzif_zb_vdd[2], ezzif_zb_vdd[3], ezzif_zb_vdd[4]);
+    printf("  ezzif GND %02X %02X %02X %02X %02X\r\n",
+            ezzif_zb_gnd[0], ezzif_zb_gnd[1], ezzif_zb_gnd[2], ezzif_zb_gnd[3], ezzif_zb_gnd[4]);
+
+    printf("\r\n");
+
+    port_read_all(p_bits);
+    printf("  MCU tristate A:%02X B:%02X C:%02X D:%02X E:%02X F:%02X G:%02X H:%02X J:%02X\r\n",
+            p_bits[0], p_bits[1], p_bits[2], p_bits[3], p_bits[4],
+            p_bits[5], p_bits[6], p_bits[7], p_bits[8]);
+
+    dir_read_all(p_bits);
+    printf("  MCU read A:%02X B:%02X C:%02X D:%02X E:%02X F:%02X G:%02X H:%02X J:%02X\r\n",
+            p_bits[0], p_bits[1], p_bits[2], p_bits[3], p_bits[4],
+            p_bits[5], p_bits[6], p_bits[7], p_bits[8]);
+
+    printf("  Latch cache 0:%02X 1:%02X 2:%02X 3:%02X 4:%02X 5:%02X 6:%02X 7:%02X\r\n",
+            latch_cache[0], latch_cache[1], latch_cache[2], latch_cache[3],
+            latch_cache[4], latch_cache[5], latch_cache[6], latch_cache[7]);
+
+    printf("  nVPP_OE: %d, nVDD_OE: %d\r\n", vpp_state(), vdd_state());
+    printf("  OEn: %02X\r\n", OEn_state());
+}
+
+
+/****************************************************************************
+DIP40
+****************************************************************************/
+
+int ezzif_valid_d40(int n) {
+    return n >= 1 && n <= 40;
+}
+
+int ezzif_assert_d40(int n) {
+    if (ezzif_valid_d40(n)) {
+        return 1;
+    } else {
+        has_error = 1;
+        return 0;
+    }
+}
+
+void ezzif_toggle_d40(int n) {
+    int ni = n - 1;
+    int off = ni / 8;
+    int mask = 1 << (ni % 8);
+
+    if (!ezzif_assert_d40(n)) {
+        return;
+    }
+
+    ezzif_zbo[off] ^= mask;
+    zif_write(ezzif_zbo);
+}
+
+void ezzif_w_d40(int n, int val) {
+    int ni = n - 1;
+    int off = ni / 8;
+    int mask = 1 << (ni % 8);
+
+    if (!ezzif_assert_d40(n)) {
+        return;
+    }
+
+    if (val) {
+        if (ezzif_zbo[off] & mask == 0) {
+            ezzif_zbo[off] = ezzif_zbo[off] | mask;
+            zif_write(ezzif_zbo);
+        }
+    } else {
+        if (ezzif_zbo[off] & mask != 0) {
+            ezzif_zbo[off] = ezzif_zbo[off] & mask;
+            zif_write(ezzif_zbo);
+        }
+    }
+}
+
+void ezzif_dir_d40(int n, int isout) {
+    int ni = n - 1;
+    int off = ni / 8;
+    int mask = 1 << (ni % 8);
+    int delta;
+
+    if (!ezzif_assert_d40(n)) {
+        return;
+    }
+
+    delta = (ezzif_zbd[off] & mask) ^ (isout ? (1 << mask) : 0);
+    if (delta) {
+        ezzif_zbd[off] = ezzif_zbd[off] ^ delta;
+        if (!is_vsafe()) {
+            return;
+        }
+        dir_write(ezzif_zbd);
+    }
+}
+
+void ezzif_io_d40(int n, int isout, int val) {
+    int ni = n - 1;
+    int off = ni / 8;
+    int mask = 1 << (ni % 8);
+
+    ezzif_dir_d40(n, isout);
+    if (isout) {
+        ezzif_w_d40(n, val);
+    }
+}
+
+void ezzif_o_d40(int n, int val) {
+    ezzif_io_d40(n, 1, val);
+}
+
+void ezzif_i_d40(int n) {
+    ezzif_io_d40(n, 0, 0);
+}
+
+int ezzif_r_d40(int n) {
+    zif_bits_t zb;
+    int ni = n - 1;
+    int off = ni / 8;
+    int mask = 1 << (ni % 8);
+
+    zif_read(zb);
+    return zb[off] & mask ? 1 : 0;
+}
+
+void zif_bit_d40(zif_bits_t zb, int n) {
+    int ni = n - 1;
+
+    zb[ni / 8] |= 1 << (ni % 8);
+}
+
+void ezzif_vdd_d40(int n, int voltset) {
+    vdd_val(voltset);
+
+    zif_bit_d40(ezzif_zb_vdd, n);
+    if (!is_vsafe()) {
+        return;
+    }
+    set_vdd(ezzif_zb_vdd);
+    vdd_en();
+}
+
+void ezzif_vpp_d40(int n, int voltset) {
+    vpp_val(voltset);
+
+    zif_bit_d40(ezzif_zb_vpp, n);
+    if (!is_vsafe()) {
+        return;
+    }
+    set_vpp(ezzif_zb_vpp);
+    vpp_en();
+}
+
+void ezzif_gnd_d40(int n) {
+    zif_bit_d40(ezzif_zb_gnd, n);
+    if (!is_vsafe()) {
+        return;
+    }
+    set_gnd(ezzif_zb_gnd);
+}
+
+
+/****************************************************************************
+Generic DIP
+****************************************************************************/
+
+void ezzif_bus_dir(const char *ns, int len, int isout) {
+    for (unsigned i = 0; i < len; ++i) {
+        ezzif_dir(ns[i], isout);
+    }
+}
+
+void ezzif_bus_w(const char *ns, int len, int val) {
+    for (unsigned i = 0; i < len; ++i) {
+        ezzif_w_d40(ezzif_dipto40(ns[i]), (val & (1 << i)) != 0);
+    }
+}
+
+int ezzif_bus_r(const char *ns, int len) {
+    int ret = 0;
+
+    for (unsigned i = 0; i < len; ++i) {
+        if (ezzif_r(ns[i])) {
+            ret |= 1 << i;
+        }
+    }
+    return ret;
+}
+

--- a/firmware/ezzif.h
+++ b/firmware/ezzif.h
@@ -1,0 +1,114 @@
+/*
+EZ ZIF (ezzif) is a library to set I/O using native DIP pin numbers and simple functions
+You should not use low level APIs unless you know what you are doing
+*/
+
+#ifndef EZZIF_H
+#define EZZIF_H
+
+#include "io.h"
+
+
+#define EZZIF_D40
+//#include "defines.h"
+
+//High level API
+//Tristate all outputs
+//Disable all voltage rails
+void ezzif_reset(void);
+void ezzif_reset_vpp(void);
+void ezzif_reset_vdd(void);
+void ezzif_reset_gnd(void);
+//Check if an error has occured and clear error status
+//Returns 0 on success, otherwise an error code
+//Ex: an invalid pin number
+int ezzif_error(void);
+//Print out lots of register states and such
+void ezzif_print_debug(void);
+
+//Low level API
+//Direction buffer
+extern zif_bits_t ezzif_zbd;
+//Output buffer
+extern zif_bits_t ezzif_zbo;
+
+
+/****************************************************************************
+DIP40
+****************************************************************************/
+
+//High level API
+//Toggle given pin
+void ezzif_toggle_d40(int n);
+//Set given pin to value (0 or 1)
+void ezzif_w_d40(int n, int val);
+//Set source / sink on given pin
+void ezzif_dir_d40(int n, int isout);
+//Set source / sink on given pin and, if output, set initial output value
+void ezzif_io_d40(int n, int isout, int val);
+//Make given pin an output and set initial value
+void ezzif_o_d40(int n, int val);
+//Make given pin an input
+void ezzif_i_d40(int n);
+//Read value on given pin
+int ezzif_r_d40(int n);
+//Attach given pin to VDD rail and set the VDD level
+void ezzif_vdd_d40(int n, int voltset);
+//Attach given pin to VPP rail and set the VPP level
+void ezzif_vpp_d40(int n, int voltset);
+//Attach given pin to ground rail
+void ezzif_gnd_d40(int n);
+
+//Low level API
+//Set given bit in zb
+void zif_bit_d40(zif_bits_t zb, int n);
+
+
+/****************************************************************************
+Generic DIP
+TODO: convert these to ni directly instead of DIP28 => d40 => ni
+****************************************************************************/
+
+//preprocess to propagate constants
+#define ezzif_dip_40to40(n) (n)
+//Pin 1 => 1
+//Pin 28 => 40, etc
+#define ezzif_dip_28to40(n) ((n) <= 28 ? (n) : (n) + 40 - 28)
+
+#if defined(EZZIF_D40)
+    #define ezzif_dipto40 ezzif_dip_40to40
+#elif defined(EZZIF_D28)
+    #define ezzif_dipto40 ezzif_dip_28to40
+#else
+    #error "Must define EZZIF_DIPN"
+#endif
+
+//High level API
+//See d40 API for definitions
+#define ezzif_toggle(n) ezzif_toggle_d40(ezzif_dipto40(n))
+#define ezzif_w(n, val) ezzif_w_d40(ezzif_dipto40(n), val)
+#define ezzif_dir(n, isout) ezzif_dir_d40(ezzif_dipto40(n), isout)
+#define ezzif_io(n, isout, val) ezzif_io_d40(ezzif_dipto40(n), isout, val)
+#define ezzif_o(n, val) ezzif_o_d40(ezzif_dipto40(n), val)
+#define ezzif_i(n) ezzif_i_d40(ezzif_dipto40(n))
+#define ezzif_r(n) ezzif_r_d40(ezzif_dipto40(n))
+#define ezzif_vdd(n, voltset) ezzif_vdd_d40(ezzif_dipto40(n), voltset)
+#define ezzif_vpp(n, voltset) ezzif_vpp_d40(ezzif_dipto40(n), voltset)
+#define ezzif_gnd(n) ezzif_gnd_d40(ezzif_dipto40(n))
+
+/*
+Bus functions
+ns: pin array
+    LSB first
+    No more than int size
+len: array length
+*/
+//Set source / sink on given pins
+void ezzif_bus_dir(const char *ns, int len, int isout);
+//Set given pins to value (0 or 1)
+void ezzif_bus_w(const char *ns, int len, int val);
+//Read value on given pins
+int ezzif_bus_r(const char *ns, int len);
+
+#endif
+

--- a/firmware/ezzif.h
+++ b/firmware/ezzif.h
@@ -9,7 +9,7 @@ You should not use low level APIs unless you know what you are doing
 #include "io.h"
 
 
-#define EZZIF_D40
+#define EZZIF_D28
 //#include "defines.h"
 
 //High level API
@@ -73,7 +73,7 @@ TODO: convert these to ni directly instead of DIP28 => d40 => ni
 #define ezzif_dip_40to40(n) (n)
 //Pin 1 => 1
 //Pin 28 => 40, etc
-#define ezzif_dip_28to40(n) ((n) <= 28 ? (n) : (n) + 40 - 28)
+#define ezzif_dip_28to40(n) ((n) <= 14 ? (n) : (n) + 40 - 28)
 
 #if defined(EZZIF_D40)
     #define ezzif_dipto40 ezzif_dip_40to40

--- a/firmware/io.h
+++ b/firmware/io.h
@@ -12,10 +12,19 @@
 extern "C" {
 #endif
 
-
+/*
+40 pins represented as 5 bytes => 40 bits
+first byte, LSB is pin 1?
+*/
 typedef unsigned char zif_bits_t[5];
+typedef const unsigned char const_zif_bits_t[5];
+//PIC MCU pins grouped by access register A-J
 typedef unsigned char port_bits_t[9]; /* PORTs A B C D E F G H J */
+//Actual latch bits
 typedef unsigned char latch_bits_t[8];
+//For debugging only
+extern latch_bits_t latch_cache;
+
 
 typedef struct port_info {
     unsigned char bank;
@@ -61,21 +70,66 @@ typedef struct latch_info {
 #define MYSTERY PORTBbits.RB1
 
 // Prototypes
+/*
+Set bit to 1 to make output
+Default: all inputs
+*/
 void dir_write(zif_bits_t zif_val);
 void dir_read(zif_bits_t zif_val);
 void zif_write(zif_bits_t zif_val);
 void zif_read(zif_bits_t zif_val);
 void write_latch(int latch_no, unsigned char val);
 void write_shreg(unsigned char in);
+
+
+//(VPP_98, VPP_126, VPP_140, VPP_166, VPP_144, VPP_171, VPP_185, VPP_212) = range(8)
+//# My measurements: 9.83, 12.57, 14.00, 16.68, 14.46, 17.17, 18.56, 21.2
+#define VPP_98 0
+#define VPP_126 1
+#define VPP_140 2
+#define VPP_166 3
+#define VPP_144 4
+#define VPP_171 5
+#define VPP_185 6
+#define VPP_212 7
+void vpp_val(unsigned char setting);
+void set_vpp(const_zif_bits_t zif);
 void vpp_en(void);
 void vpp_dis(void);
+int vpp_state(void);
+
+//(VDD_30, VDD_35, VDD_46, VDD_51, VDD_43, VDD_48, VDD_60, VDD_65) = range(8)
+//# My measurements: 2.99, 3.50, 4.64, 5.15, 4.36, 4.86, 6.01, 6.52
+#define VDD_30 0
+#define VDD_35 1
+#define VDD_46 2
+#define VDD_51 3
+#define VDD_43 4
+#define VDD_48 5
+#define VDD_60 6
+#define VDD_65 7
+void vdd_val(unsigned char setting);
+void set_vdd(const_zif_bits_t zif);
 void vdd_en(void);
 void vdd_dis(void);
-void set_vpp(zif_bits_t zif);
-void set_vdd(zif_bits_t zif);
-void set_gnd(zif_bits_t zif);
-void vpp_val(unsigned char setting);
-void vdd_val(unsigned char setting);
+int vdd_state(void);
+
+void set_gnd(const_zif_bits_t zif);
+
+//Low level API
+//MCU
+//Write MCU pin output values
+//You must also set tristate (dir_write_all()) if you want to actually drive out
+void port_write_all(port_bits_t p_bits);
+//Read MCU pins
+void port_read_all(port_bits_t p_bits);
+//Set MCU tristate. 1 => output
+void dir_write_all(port_bits_t p_bits);
+//Read tristate setting
+void dir_read_all(port_bits_t p_bits);
+//This should always return 0x00 (no latches enabled)
+int OEn_state(void);
+
 
 
 #ifdef	__cplusplus

--- a/firmware/modes/ezzif/main.c
+++ b/firmware/modes/ezzif/main.c
@@ -1,0 +1,202 @@
+//27C256
+
+//#include "epromv.h"
+#include "../../mode.h"
+#include "../../comlib.h"
+
+#include "ezzif.h"
+
+static inline void print_banner(void)
+{
+    com_println("   | |");
+    com_println(" ==[+]==  open-tl866 Programmer Mode (EZZIF)");
+    com_println("   | |    TASTY SNACK EDITION.");
+}
+
+static inline void print_help(void)
+{
+    com_println("Commands:");
+    com_println("  0: digital I/O test");
+    com_println("  1: VPP sweep test");
+    com_println("  2: VDD sweep test");
+    com_println("  3: multiple voltage rail test");
+    com_println("  4: no ground test");
+}
+
+static void prompt_enter(void) {
+    com_println("Press enter to continue");
+    com_readline();
+}
+
+static void prompt_msg(const char *msg) {
+    //ezzif_print_debug();
+    com_println(msg);
+    com_readline();
+}
+
+static inline void eval_command(unsigned char * cmd)
+{
+    unsigned char * cmd_t = strtok(cmd, " ");
+
+    ezzif_reset();
+    switch (cmd_t[0]) {
+        case '0':
+        {
+            com_println("Digital test");
+            com_println("1: 1, 2: 0, 3: 1, 4: 0, 5: Z, 6: Z");
+            ezzif_gnd(20);
+            ezzif_io_d40(1, 1, 1);
+            ezzif_io_d40(2, 1, 0);
+            ezzif_io_d40(3, 1, 1);
+            ezzif_io_d40(4, 1, 0);
+            ezzif_io_d40(5, 0, 0);
+            ezzif_io_d40(6, 0, 0);
+            printf("Done, error: %i\r\n", ezzif_error());
+            prompt_enter();
+            break;
+        }
+
+        case '1':
+        {
+            static const char VPPS[] = {VPP_98, VPP_126, VPP_140, VPP_166, VPP_144, VPP_171, VPP_185, VPP_212};
+            com_println("Sweeping VPP pin 1, gnd 40");
+            com_println("Reference: 9.83, 12.57, 14.00, 16.68, 14.46, 17.17, 18.56, 21.2");
+            ezzif_gnd_d40(40);
+            for (unsigned i = 0; i < sizeof(VPPS); ++i) {
+                ezzif_vpp_d40(1, VPPS[i]);
+                printf("Set enum %u\r\n", VPPS[i]);
+                prompt_enter();
+            }
+            printf("Done, error: %i\r\n", ezzif_error());
+            break;
+        }
+
+        case '2':
+        {
+            static const char VDDS[] = {VDD_30, VDD_35, VDD_46, VDD_51, VDD_43, VDD_48, VDD_60, VDD_65};
+            com_println("Sweeping VDD pin 1, gnd 40");
+            com_println("Reference: 2.99, 3.50, 4.64, 5.15, 4.36, 4.86, 6.01, 6.52");
+            ezzif_gnd_d40(40);
+            for (unsigned i = 0; i < sizeof(VDDS); ++i) {
+                ezzif_vdd_d40(1, VDDS[i]);
+                printf("Set enum %u\r\n", VDDS[i]);
+                prompt_enter();
+            }
+            printf("Done, error: %i\r\n", ezzif_error());
+            break;
+        }
+
+        case '3':
+        {
+            com_println("Voltage rail test");
+            com_println("1: VPP 10V");
+            com_println("2: VDD 5V");
+            com_println("40: GND");
+
+            com_println("");
+
+
+            /*
+            Test rails operate normally
+            */
+
+            com_println("");
+            com_println("Testing normal operation");
+            ezzif_reset();
+            ezzif_vpp_d40(1, VPP_98);
+            ezzif_gnd(40);
+            prompt_msg("10 Check 10V: 1 to 40 (VPP to GND)");
+
+            ezzif_vdd_d40(2, VDD_48);
+            prompt_msg("11 Check 5V: 2 to 40 (VDD to GND)");
+            prompt_msg("12 Check 5V: 1 to 2 (VPP to VDD)");
+
+
+            /*
+            Turn off rails
+            Verify no voltage
+            */
+
+            com_println("");
+            com_println("Testing rail shut off");
+            ezzif_reset_vpp();
+            ezzif_gnd(40);
+            prompt_msg("20 Check 0V: 1 to 40 (VPP off)");
+            prompt_msg("21 Check 5V: 2 to 40 (VDD to GND)");
+
+            ezzif_reset_vdd();
+            prompt_msg("22 Check 0V: 2 to 40 (VDD off)");
+
+            
+            /*
+            Turn off ground
+            Verify no voltage
+            */
+
+            /*
+            com_println("");
+            com_println("Testing ground shut off");
+            com_println("WARNING: test faulty?");
+            ezzif_reset();
+            ezzif_gnd(40);
+            ezzif_vpp_d40(1, VPP_98);
+            ezzif_vdd_d40(2, VDD_48);
+            prompt_msg("30 Check 10V: 1 to 40 (VPP to GND)");
+            prompt_msg("31 Check 5V: 2 to 40 (VDD to GND)");
+
+            ezzif_reset_gnd();
+            prompt_msg("33 Check 0V: 1 to 40 (VPP GND off)");
+            prompt_msg("34 Check 0V: 2 to 40 (VDD GND off)");
+            */
+
+            com_println("");
+            printf("Done, error: %i\r\n", ezzif_error());
+            break;
+        }
+
+        case '4':
+        {
+            ezzif_vpp_d40(1, VPP_98);
+            ezzif_vdd_d40(2, VDD_48);
+            prompt_msg("10 Check 10V: 1 to 40 (VPP to GND)");
+            break;
+        }
+
+        case 's': {
+            ezzif_print_debug();
+            break;
+        }
+
+        case '?':
+        case 'h':
+            print_help();
+            break;
+        case 'V':
+            //print_version();
+            break;
+        default:
+            printf("Error: Unknown command.");
+    }
+    ezzif_reset();
+}
+
+void mode_main(void) {
+    ezzif_reset();
+    
+    // Wait for user interaction (press enter).
+    com_readline();
+
+    print_banner();
+    print_help();
+    enable_echo();
+
+    unsigned char * cmd;
+
+    while(1) {
+        printf("\r\nCMD> ");
+        cmd = com_readline();
+        com_println("");
+        eval_command(cmd);
+    }    
+}
+


### PR DESCRIPTION
ezzif wraps the low level primitives API in io.h by adding state management and APIs to manipulate this state. This allows simple functions to toggle one pin at a time

Misc:
- io:send_char_sync(): don't use strcpy() since putch() input is char and not NULL terminated
- io:send_string_sync(): use strncpy to protect during large sends
- io: VPP/VDD: add voltage defines
- io: add const_zif_bits_t
- io: add get vpp/vdd EN state functions
- io: add some comments on bit arrays
- comlib: add latch cache for debugging

