### PR TITLE
Adds note for xc8 Linux install gotcha.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This firmware replaces the proprietary firmware for programming EPROMs, MCUs, GA
    [Download it from Microchip's site][xc8] and install it.
    When activating, select the Free version.
 
+   **Note:** If you are installing to a 64-bit Ubuntu distribution,
+   you must first get the 32-bit libc that isn't installed by default:
+   `sudo apt-get install libc6:i386`. Then you can run Microchip's
+   installer.
+
 1. CMake is needed to generate the build configuration. On Linux you
    should install it from your distribution's package manager
    (e.g. `sudo apt-get install cmake`). For Windows, an installer is


### PR DESCRIPTION
To save anyone from wasting time Googling why the xc8 installer silently dies on 64-bit Ubuntu.