### PR TITLE
[typo] tl866-at86 -> tl866-at89 in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ corresponding target in the makefiles, so you can build just one mode
 with e.g. `make tl866-bitbang`. The currently implemented modes are:
 
 * `tl866-bitbang`
-* `tl866-at86`
+* `tl866-at89`
 
 ## Device Drivers and Configuration
 


### PR DESCRIPTION
The mode is 89, not 86.