### PR TITLE
bitbang test: remove bus contention

### DIFF
--- a/py/test/test_bitbang.py
+++ b/py/test/test_bitbang.py
@@ -21,7 +21,7 @@ class TestCase(unittest.TestCase):
 
     def test_io(self):
         """Set I/O out and read back that value"""
-        # Tried tristating unused but the float around
+        # Tried tristating unused but they float around
         self.tl.io_tri(0)
         for pini in range(40):
             mask = 1 << pini
@@ -36,6 +36,11 @@ class TestCase(unittest.TestCase):
         # Any value really
         self.tl.vpp_volt(aclient.VPP_98)
         for pini in aclient.VPP_PINS0:
+            # Pre-charge I/O low
+            self.tl.io_tri(0)
+            self.tl.io_w(0)
+            self.tl.io_tri(0xFFFFFFFFFF)
+
             mask = 1 << pini
             self.tl.vpp_pins(mask)
             readback = self.tl.io_r()
@@ -45,10 +50,28 @@ class TestCase(unittest.TestCase):
 
     def test_vdd(self):
         """Set VDD out and verify its set via digital I/O"""
+        """
+        Must tristate or will get contention
+        Rely on some capacitive hold over to verify pin was actually toggled
+        IO vs VDD test
+
+        VDD_30, IO=Z: 3.21V
+        VDD_30, IO=0: 2.36V
+        VDD_30, IO=1: 3.40V
+
+        VDD_65, IO=Z: 5.57V
+        VDD_65, IO=0: 2.55V (and falling)
+        VDD_65, IO=1: 5.49V
+        """
         self.tl.vdd_en()
         # Any value really
         self.tl.vdd_volt(aclient.VDD_30)
         for pini in aclient.VDD_PINS0:
+            # Pre-charge I/O low
+            self.tl.io_tri(0)
+            self.tl.io_w(0)
+            self.tl.io_tri(0xFFFFFFFFFF)
+
             mask = 1 << pini
             self.tl.vdd_pins(mask)
             readback = self.tl.io_r()


### PR DESCRIPTION
Fixes failure like:

```
python3 test/test_bitbang.py TestCase.test_vdd
F
======================================================================
FAIL: test_vdd (__main__.TestCase)
Set VDD out and verify its set via digital I/O
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_bitbang.py", line 57, in test_vdd
    self.assertEqual(mask, readbackm)
AssertionError: 1 != 0

----------------------------------------------------------------------
Ran 1 test in 0.195s

FAILED (failures=1)
```